### PR TITLE
Use PUBLIC_URL for router basename

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyles />
-      <Router basename="/if-juku-site">
+      <Router basename={process.env.PUBLIC_URL || '/'}>
         <div className="App">
           <Routes>
             <Route path="/" element={<HomePage />} />


### PR DESCRIPTION
## Summary
- derive router base path from `process.env.PUBLIC_URL` to keep asset paths accurate

## Testing
- `npm run check-images`
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b598cdbcc083319a49a20fae236ac5